### PR TITLE
Updated pgweb installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
   ```
 
   You should also install a visual tool for PostgreSQL, pick one:
-  - [pgweb](https://github.com/sosedoff/pgweb) (`$ brew install pgweb`)
+  - [pgweb](https://github.com/sosedoff/pgweb) (`$ brew cask install pgweb`)
   - [postico](https://eggerapps.at/postico/)
 
 ### Install Redis on your system


### PR DESCRIPTION
The [pgweb](https://github.com/sosedoff/pgweb/) is distributed via [cask](https://caskroom.github.io/) and it has to be installed using

```sh
brew cask install pgweb
```
sosedoff/pgweb#315