### PR TITLE
Update pgweb download script in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@
   ```
 
   You should also install a visual tool for PostgreSQL, pick one:
-  - [pgweb](https://github.com/sosedoff/pgweb) (`$ brew cask install pgweb`)
+  - [pgweb](https://github.com/sosedoff/pgweb) (`$ brew install pgweb`)
   - [postico](https://eggerapps.at/postico/)
 
 ### Install Redis on your system


### PR DESCRIPTION
The pgweb in the original README is outdated, and I updated it based on [the official pgweb github](https://github.com/sosedoff/pgweb/wiki/Installation)